### PR TITLE
Feature/firestore-crowdy-chat

### DIFF
--- a/firestore/crowdy-chat/firestore.rules
+++ b/firestore/crowdy-chat/firestore.rules
@@ -175,7 +175,7 @@ service cloud.firestore {
 			// Array validation for leadStages
 			request.resource.data.keys().hasOnly([
 					'name', 'objective', 'createdBy', 'createdAt', 'updatedAt',
-					'status', 'openAIKey', 'replySpeed', 'reminderTiming', 'chatgpt', 'organizationId'
+					'status', 'openAIKey', 'replySpeed', 'reminderTiming', 'chatgpt', 'organizationId', "assistantId"
 					]);
 			// (request.resource.data.leadStages is list);
 	}

--- a/firestore/crowdy-chat/models/campaigns.ts
+++ b/firestore/crowdy-chat/models/campaigns.ts
@@ -27,6 +27,9 @@ export interface ICampaigns {
         actor: string;
         examples: string;
     };
+
+    assistantId?: string
+
     leadStages: ICollection<LeadStage>;
     conversations: ICollection<IConversation>;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an `assistantId` field to the Firestore security rules, enhancing data validation capabilities.
	- Added an optional `assistantId` property to the `ICampaigns` interface, allowing for better association of campaigns with specific assistants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->